### PR TITLE
[search-documents] Fix ISO8601 date regex

### DIFF
--- a/sdk/search/search-documents/src/serialization.ts
+++ b/sdk/search/search-documents/src/serialization.ts
@@ -3,7 +3,7 @@
 
 import GeographyPoint from "./geographyPoint";
 
-const ISO8601DateRegex = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z/i;
+const ISO8601DateRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z$/i;
 const GeoJSONPointTypeName = "Point";
 const WorldGeodeticSystem1984 = "EPSG:4326"; // See https://epsg.io/4326
 


### PR DESCRIPTION
I've updated the regex to match the entire string, not just a part of the string, meaning that fields that contain ISO8601 dates within them aren't treated as dates themselves.

See #10486 for more info.